### PR TITLE
don't truncate floats but round them before casting them to ints

### DIFF
--- a/Lib/cu2qu/__init__.py
+++ b/Lib/cu2qu/__init__.py
@@ -136,7 +136,7 @@ def as_quadratic(segment, points):
         return segment.as_quadratic(points)
     except AttributeError:
         return RSegment(
-            'qcurve', [[int(i) for i in p] for p in points], segment.smooth)
+            'qcurve', [[int(round(i)) for i in p] for p in points], segment.smooth)
 
 
 class FontCollection:


### PR DESCRIPTION
First of all, thank you James and Behdad for making this available!

The core algorithm in `cubic_approx` function (at [line 120](https://github.com/googlei18n/cu2qu/blob/master/Lib/cu2qu.py#L120)) is as simple as it is elegant.

I've been testing it today and I'm already impressed by the results. I have a few comments and a small patch already (I've already signed the CLA for brotli so I presume it should apply here too).

Firstly, I would like to see this working as a Pen, in the fonttools/robofab sense. Currently, the script replaces the `objectsRF.RSegment` objects in place; this means, it doesn't work in other Robofab "worlds", e.g. `objectsFL` for example, whose objects have slightly different attributes, etc.
The pen protocol would allow the converter to abstract from the specifics of each implementation.

Second, I believe the default `max_err` of 10 is a bit too generous, and may be reduced to 2, or something like that for greater accuracy.

Furthermore, the `curve_spline_dist` function calculates the distance between the cubic and the quadratic spline at sampled values of the parameter `t`. This is not necessarily the minimum distance between the curves, as they may well have different parametrisations. I think a better approach would be to compute the projection on the quadratic spline of sampled points from the cubic. It could make it a bit slower, but surely it will be more accurate. 
I found a blog post in which they explain how to find out a point on a Quadratic Bezier which is the closest possible to another point lying outside of it:

http://blog.gludion.com/2009/08/distance-to-quadratic-bezier-curve.html 

Also, instead of taking the max error, you may wish to use the "root mean square", ie. the square root of the mean of the squares of the sampled distances.

Anyway, I'll give it more tests in the next days.
Here's a little fix to make sure floating point numbers are not truncated but rounded to the closest integer. In Python, in fact, `int(0.999999999) == 0`.

Thanks again and keep up the good work! :+1: 