### PR TITLE
Specify tolerance in em through `max_err_em`

### DIFF
--- a/Lib/cu2qu/rf.py
+++ b/Lib/cu2qu/rf.py
@@ -46,11 +46,16 @@ def fonts_to_quadratic(*fonts, **kwargs):
     font at a time may yield slightly more optimized results.
     """
 
-    max_n = kwargs.get('max_n', 10)
-    max_err = kwargs.get('max_err', 0.0025)
-    max_errors = [f.info.unitsPerEm * max_err for f in fonts]
     report = kwargs.get('report', {})
     dump_report = kwargs.get('dump_report', False)
+    max_n = kwargs.get('max_n', 10)
+
+    max_err_em = kwargs.get('max_err_em', 0.0025)
+    max_err = kwargs.get('max_err', None)
+    if max_err:
+        max_errors = [max_err] * len(fonts)
+    else:
+        max_errors = [f.info.unitsPerEm * max_err_em for f in fonts]
 
     for glyph in FontCollection(fonts):
         glyph_to_quadratic(glyph, max_errors, max_n, report)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Some fonts may need a different error threshold than the default (0.0025 em).
 This can also be provided by the caller:
 
 ```python
-fonts_to_quadratic(thin_font, bold_font, max_err=0.005)
+fonts_to_quadratic(thin_font, bold_font, max_err_em=0.005)
 ```
 
 ```python
 for font in [thin_font, bold_font]:
-    fonts_to_quadratic(font, max_err=0.001)
+    fonts_to_quadratic(font, max_err_em=0.001)
 ```
 
 `fonts_to_quadratic` can print a string reporting the number of curves of each


### PR DESCRIPTION
Based on follow-up discussion in #1. Makes API generally compatible until we all agree on something.