### PR TITLE
Return (spline, error) tuple from approximation functions

### DIFF
--- a/Lib/cu2qu/rf.py
+++ b/Lib/cu2qu/rf.py
@@ -118,10 +118,10 @@ def points_to_quadratic(p0, p1, p2, p3, max_err, max_n):
 
     if hasattr(p0, 'x'):
         curve = [(float(i.x), float(i.y)) for i in [p0, p1, p2, p3]]
-        return curve_to_quadratic(curve, max_err, max_n)
+        return curve_to_quadratic(curve, max_err, max_n)[0]
 
     curves = [[(float(i.x), float(i.y)) for i in p] for p in zip(p0, p1, p2, p3)]
-    return curves_to_quadratic(curves, max_err, max_n)
+    return curves_to_quadratic(curves, max_err, max_n)[0]
 
 
 def replace_segments(contour, segments):


### PR DESCRIPTION
This is in reply to @jamesgk's https://github.com/googlei18n/cu2qu/issues/13#issuecomment-161102289.

`curve_to_quadratic` now returns a tuple with the quadratic spline and the error of approximation; similarly, `curves_to_quadratic` return a tuple with the list of quadratic splines and the corresponding list of approximation errors.

The functions also raise a custom `ApproxNotFoundError` when no approximation can be found for a given curve within the `max_n` and `max_err` provided. The curve and error are stored as attributes in the exception.

Also, for consistency, the quadratic spline is always returned as a list of tuples. Previously, for the special n = 1 case, it would return a tuple of tuples.