### PR TITLE
[robofab] Don't round new points

### DIFF
--- a/Lib/cu2qu/rf.py
+++ b/Lib/cu2qu/rf.py
@@ -172,8 +172,7 @@ def as_quadratic(segment, points):
     try:
         return segment.as_quadratic(points)
     except AttributeError:
-        return RSegment(
-            'qcurve', [[int(round(i)) for i in p] for p in points], segment.smooth)
+        return RSegment('qcurve', points, segment.smooth)
 
 
 class FontCollection:


### PR DESCRIPTION
It doesn't seem to be a good idea to round some points in a glyph but not others. With this change, control points (which don't change) that were equivalent to other non-curve points before conversion will remain so. This can be significant when drawing with pen objects. (see for example https://github.com/robofab-developers/robofab/blob/master/Lib/robofab/objects/objectsBase.py#L1984)

The rounding has been there since the initial commit; it's not clear that it serves a purpose.

@anthrotype do you have an opinion on this? Another option is to round everything. Also I noticed that the rounding in [TTGlyphPen](https://github.com/behdad/fonttools/blob/master/Lib/fontTools/pens/ttGlyphPen.py#L30) does not use `round()` and maybe should.