### PR TITLE
Report number of segments in result, not points

### DIFF
--- a/Lib/cu2qu/test/cu2qu_test.py
+++ b/Lib/cu2qu/test/cu2qu_test.py
@@ -67,17 +67,17 @@ class CurveToQuadraticTest(unittest.TestCase):
         """
 
         expected = {
-            3: 6,
-            4: 26,
-            5: 82,
-            6: 232,
-            7: 360,
-            8: 266,
-            9: 28}
+            2: 6,
+            3: 26,
+            4: 82,
+            5: 232,
+            6: 360,
+            7: 266,
+            8: 28}
 
         results = collections.defaultdict(int)
         for spline in self.single_splines:
-            n = len(spline) - 1
+            n = len(spline) - 2
             results[n] += 1
         self.assertEqual(results, expected)
         self.results.append(('single spline lengths', results))
@@ -86,16 +86,16 @@ class CurveToQuadraticTest(unittest.TestCase):
         """Test that conversion results are unchanged for multiple curves."""
 
         expected = {
-            6: 11,
-            7: 35,
-            8: 49,
-            9: 5}
+            5: 11,
+            6: 35,
+            7: 49,
+            8: 5}
 
         results = collections.defaultdict(int)
         for splines in self.compat_splines:
-            n = len(splines[0]) - 1
+            n = len(splines[0]) - 2
             for spline in splines[1:]:
-                self.assertEqual(len(spline) - 1, n,
+                self.assertEqual(len(spline) - 2, n,
                     'Got incompatible conversion results')
             results[n] += 1
         self.assertEqual(results, expected)

--- a/Lib/cu2qu/ufo.py
+++ b/Lib/cu2qu/ufo.py
@@ -130,9 +130,9 @@ def _segments_to_quadratic(segments, max_err, stats):
     n = len(new_points[0])
     assert all(len(s) == n for s in new_points[1:]), 'Converted incompatibly'
 
-    n = str(n)
+    spline_length = str(n - 2)
     if stats is not None:
-        stats[n] = stats.get(n, 0) + 1
+        stats[spline_length] = stats.get(spline_length, 0) + 1
 
     return [('qcurve', p) for p in new_points]
 


### PR DESCRIPTION
For some reason, I was subtracting 1 from the spline lengths in the
test report. Not sure why that is, so I've assumed it was wrong (and
now we subtract 2 to get the length in number of segments).

Resolves https://github.com/googlei18n/cu2qu/issues/39