### PR TITLE
[ufo] in fonts_to_quadratic, iterate over union of glyph names

### DIFF
--- a/Lib/cu2qu/ufo.py
+++ b/Lib/cu2qu/ufo.py
@@ -225,8 +225,8 @@ def fonts_to_quadratic(
     assert len(max_errors) == len(fonts)
 
     modified = False
-    for glyphs in zip(*fonts):
-        name = glyphs[0].name
+    for name in set().union(*(f.keys() for f in fonts)):
+        glyphs = [font[name] for font in fonts if name in font]
         assert all(g.name == name for g in glyphs), 'Incompatible fonts'
         modified |= _glyphs_to_quadratic(
             glyphs, max_errors, reverse_direction, stats)

--- a/Lib/cu2qu/ufo.py
+++ b/Lib/cu2qu/ufo.py
@@ -226,10 +226,14 @@ def fonts_to_quadratic(
 
     modified = False
     for name in set().union(*(f.keys() for f in fonts)):
-        glyphs = [font[name] for font in fonts if name in font]
-        assert all(g.name == name for g in glyphs), 'Incompatible fonts'
+        glyphs = []
+        my_errors = []
+        for font, error in zip(fonts, max_errors):
+            if name in font:
+                glyphs.append(font[name])
+                my_errors.append(error)
         modified |= _glyphs_to_quadratic(
-            glyphs, max_errors, reverse_direction, stats)
+            glyphs, my_errors, reverse_direction, stats)
 
     if modified and dump_stats:
         spline_lengths = sorted(stats.keys())


### PR DESCRIPTION
Only convert compatibly glyphs with same name in multiple fonts.

Don't use zip(*fonts) as defcon fonts are dictionary-like objects and the ordering of the glyphs returned by __iter__ method is undefined.

Should fix #48

cc @typemytype