### PR TITLE
[ufo] when reverse_direction is True, we always want to modify the input glyphs

### DIFF
--- a/Lib/cu2qu/ufo.py
+++ b/Lib/cu2qu/ufo.py
@@ -143,16 +143,12 @@ def _glyphs_to_quadratic(glyphs, max_err, reverse_direction, stats):
     Return True if the glyphs were modified, else return False.
     """
 
-    if reverse_direction:
-        # always modify input glyphs if reverse_direction is True
-        glyphs_modified = True
-    else:
-        # only modify input glyphs if they contain any cubic curves
-        glyphs_modified = False
-
     segments_by_location = zip(*[_get_segments(g) for g in glyphs])
     if not any(segments_by_location):
-        return glyphs_modified
+        return False
+
+    # always modify input glyphs if reverse_direction is True
+    glyphs_modified = reverse_direction
 
     new_segments_by_location = []
     for segments in segments_by_location:

--- a/Lib/cu2qu/ufo.py
+++ b/Lib/cu2qu/ufo.py
@@ -143,7 +143,12 @@ def _glyphs_to_quadratic(glyphs, max_err, reverse_direction, stats):
     Return True if the glyphs were modified, else return False.
     """
 
-    glyphs_modified = False
+    if reverse_direction:
+        # always modify input glyphs if reverse_direction is True
+        glyphs_modified = True
+    else:
+        # only modify input glyphs if they contain any cubic curves
+        glyphs_modified = False
 
     segments_by_location = zip(*[_get_segments(g) for g in glyphs])
     if not any(segments_by_location):


### PR DESCRIPTION
Sorry, I introduced this bug with https://github.com/googlei18n/cu2qu/pull/45

We want to reverse the contour direction of all the glyphs in the font, even if they are just made of straight lines.
Currently, the direction is only flipped if the glyph contains at least one cubic curve.
 