### PR TITLE
Fix License classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
The project LICENSE file and some files in the project refer to ASL 2.0
not to the MIT License. Thus, this commit changes the classifier to
refer to the actual license.