### PR TITLE
[pens] fix number of segments reported in stats

### DIFF
--- a/Lib/cu2qu/pens.py
+++ b/Lib/cu2qu/pens.py
@@ -76,7 +76,7 @@ class Cu2QuPen(AbstractPen):
         curve = (self.current_pt, pt1, pt2, pt3)
         quadratic = curve_to_quadratic(curve, self.max_err)
         if self.stats is not None:
-            n = str(len(quadratic))
+            n = str(len(quadratic) - 2)
             self.stats[n] = self.stats.get(n, 0) + 1
         self.qCurveTo(*quadratic[1:])
 
@@ -148,7 +148,7 @@ class Cu2QuPointPen(BasePointToSegmentPen):
                     cubic = [prev_on_curve, bcp1, bcp2, on_curve]
                     quad = curve_to_quadratic(cubic, self.max_err)
                     if self.stats is not None:
-                        n = str(len(quad))
+                        n = str(len(quad) - 2)
                         self.stats[n] = self.stats.get(n, 0) + 1
                     new_points = [(pt, False, None, {}) for pt in quad[1:-1]]
                     new_points.append((on_curve, smooth, name, kwargs))

--- a/Lib/cu2qu/test/pens_test.py
+++ b/Lib/cu2qu/test/pens_test.py
@@ -69,8 +69,8 @@ class _TestPenMixin(object):
             self.convert_glyph(source, stats=stats)
 
         self.assertTrue(stats)
-        self.assertTrue('4' in stats)
-        self.assertEqual(type(stats['4']), int)
+        self.assertTrue('1' in stats)
+        self.assertEqual(type(stats['1']), int)
 
     def test_addComponent(self):
         pen = self.Pen()


### PR DESCRIPTION
It appears we were reporting the 'stats' differently in the pens and in the main ufo module.

https://github.com/googlei18n/cu2qu/blob/7a2f638/Lib/cu2qu/ufo.py#L148

You can git blame me, sorry.
Funny how it's been broken for almost two years :)