### PR TITLE
Error handling

### DIFF
--- a/Lib/cu2qu/__init__.py
+++ b/Lib/cu2qu/__init__.py
@@ -15,7 +15,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-__version__ = "1.3.0"
+__version__ = "1.3.1.dev0"
 
 __all__ = ['curve_to_quadratic', 'curves_to_quadratic']
 

--- a/Lib/cu2qu/errors.py
+++ b/Lib/cu2qu/errors.py
@@ -1,0 +1,49 @@
+from __future__ import print_function, absolute_import, division
+
+
+class UnequalZipLengthsError(ValueError):
+    pass
+
+
+class IncompatibleGlyphsError(ValueError):
+
+    def __init__(self, glyphs):
+        assert len(glyphs) > 1
+        self.glyphs = glyphs
+        names = set(repr(g.name) for g in glyphs)
+        if len(names) > 1:
+            self.combined_name = "{%s}" % ", ".join(sorted(names))
+        else:
+            self.combined_name = names.pop()
+
+    def __repr__(self):
+        return "<%s %s>" % (type(self).__name__, self.combined_name)
+
+
+class IncompatibleSegmentNumberError(IncompatibleGlyphsError):
+
+    def __str__(self):
+        return "Glyphs named %s have different number of segments" % (
+            self.combined_name)
+
+
+class IncompatibleSegmentTypesError(IncompatibleGlyphsError):
+
+    def __init__(self, glyphs, segments):
+        IncompatibleGlyphsError.__init__(self, glyphs)
+        self.segments = segments
+
+    def __str__(self):
+        from pprint import pformat
+        return "Glyphs named %s have incompatible segment types:\n%s" % (
+            self.combined_name, pformat(self.segments))
+
+
+class IncompatibleFontsError(ValueError):
+
+    def __init__(self, glyph_errors):
+        self.glyph_errors = glyph_errors
+
+    def __str__(self):
+        return "fonts contains incompatible glyphs: %s" % (
+            ", ".join(repr(g) for g in sorted(self.glyph_errors.keys())))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1.dev0
 commit = True
 tag = False
 tag_name = v{new_version}

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name='cu2qu',
-    version="1.3.0",
+    version="1.3.1.dev0",
     description='Cubic-to-quadratic bezier curve conversion',
     author="James Godfrey-Kittle, Behdad Esfahbod",
     author_email="jamesgk@google.com",


### PR DESCRIPTION
Based on Miguel Sousa's original PR and the following discussion: #114

Instead of raising an error at the first incompatible glyph, we let it continue (keeping the original contours unmodified when that happens), and use logging to print error messages.

A new `IncompatibleFontsError` exception is raised at the end of `fonts_to_quadratic` if any glyph has incompatible number or types of segments.

The exception instance has a `glyph_errors` attribute (dict) which collects all the individual IncompatibleGlyphsError keyed by glyph name.

/cc @miguelsousa